### PR TITLE
added postman and swagger files to bank apps

### DIFF
--- a/java-apps/bank-analysis/bank-analysis.postman_collection.json
+++ b/java-apps/bank-analysis/bank-analysis.postman_collection.json
@@ -1,0 +1,28 @@
+{
+	"info": {
+		"_postman_id": "f74c7c3f-55a3-4186-bb40-11578255a723",
+		"name": "bank-analysis",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "index",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8111/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8111",
+					"path": [
+						""
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/java-apps/bank-analysis/pom.xml
+++ b/java-apps/bank-analysis/pom.xml
@@ -64,6 +64,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-boot-starter</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.20</version>

--- a/java-apps/bank-analysis/swagger-bank-analysis.json
+++ b/java-apps/bank-analysis/swagger-bank-analysis.json
@@ -1,0 +1,1234 @@
+{
+	"openapi": "3.0.3",
+	"info": {
+		"title": "Api Documentation",
+		"description": "Api Documentation",
+		"termsOfService": "urn:tos",
+		"contact": {},
+		"license": {
+			"name": "Apache 2.0",
+			"url": "http://www.apache.org/licenses/LICENSE-2.0"
+		},
+		"version": "1.0"
+	},
+	"servers": [
+		{
+			"url": "http://localhost:8111",
+			"description": "Inferred Url"
+		}
+	],
+	"tags": [
+		{
+			"name": "basic-error-controller",
+			"description": "Basic Error Controller"
+		},
+		{
+			"name": "home-controller",
+			"description": "Home Controller"
+		},
+		{
+			"name": "operation-handler",
+			"description": "Operation Handler"
+		},
+		{
+			"name": "web-mvc-links-handler",
+			"description": "Web Mvc Links Handler"
+		}
+	],
+	"paths": {
+		"/error": {
+			"get": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "error",
+				"operationId": "errorUsingGET",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"put": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "error",
+				"operationId": "errorUsingPUT",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"post": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "error",
+				"operationId": "errorUsingPOST",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "error",
+				"operationId": "errorUsingDELETE",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"options": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "error",
+				"operationId": "errorUsingOPTIONS",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"head": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "error",
+				"operationId": "errorUsingHEAD",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"patch": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "error",
+				"operationId": "errorUsingPATCH",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"trace": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "error",
+				"operationId": "errorUsingTRACE",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			}
+		},
+		"/": {
+			"get": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingGET",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"put": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingPUT",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"post": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingPOST",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingDELETE",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"options": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingOPTIONS",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"head": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingHEAD",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"patch": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingPATCH",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"trace": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingTRACE",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			}
+		},
+		"/check-loan-credibility": {
+			"get": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "checkLoanCredibility",
+				"operationId": "checkLoanCredibilityUsingGET",
+				"parameters": [
+					{
+						"name": "clientName",
+						"in": "query",
+						"description": "clientName",
+						"required": true,
+						"style": "form",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/convert-currency": {
+			"get": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "convertCurrency",
+				"operationId": "convertCurrencyUsingGET",
+				"parameters": [
+					{
+						"name": "amount",
+						"in": "query",
+						"description": "amount",
+						"required": true,
+						"style": "form",
+						"schema": {
+							"type": "integer",
+							"format": "int64"
+						}
+					},
+					{
+						"name": "sourceCurrency",
+						"in": "query",
+						"description": "sourceCurrency",
+						"required": true,
+						"style": "form",
+						"schema": {
+							"type": "string",
+							"enum": [
+								"GBP",
+								"NIS",
+								"USD"
+							]
+						}
+					},
+					{
+						"name": "targetCurrency",
+						"in": "query",
+						"description": "targetCurrency",
+						"required": true,
+						"style": "form",
+						"schema": {
+							"type": "string",
+							"enum": [
+								"GBP",
+								"NIS",
+								"USD"
+							]
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "number",
+									"format": "double"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/cross-http": {
+			"get": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "forwardInputToDotnetCoreEntryPoint",
+				"operationId": "forwardInputToDotnetCoreEntryPointUsingGET",
+				"parameters": [
+					{
+						"name": "name",
+						"in": "query",
+						"description": "name",
+						"required": true,
+						"style": "form",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/home": {
+			"get": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankAnalysisIndex",
+				"operationId": "bankAnalysisIndexUsingGET",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"put": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankAnalysisIndex",
+				"operationId": "bankAnalysisIndexUsingPUT",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"post": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankAnalysisIndex",
+				"operationId": "bankAnalysisIndexUsingPOST",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankAnalysisIndex",
+				"operationId": "bankAnalysisIndexUsingDELETE",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"options": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankAnalysisIndex",
+				"operationId": "bankAnalysisIndexUsingOPTIONS",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"head": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankAnalysisIndex",
+				"operationId": "bankAnalysisIndexUsingHEAD",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"patch": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankAnalysisIndex",
+				"operationId": "bankAnalysisIndexUsingPATCH",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"trace": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankAnalysisIndex",
+				"operationId": "bankAnalysisIndexUsingTRACE",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			}
+		},
+		"/name": {
+			"get": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "forwardInputToSqlService",
+				"operationId": "forwardInputToSqlServiceUsingGET",
+				"parameters": [
+					{
+						"name": "name",
+						"in": "query",
+						"description": "name",
+						"required": true,
+						"style": "form",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/actuator/health": {
+			"get": {
+				"tags": [
+					"operation-handler"
+				],
+				"summary": "handle",
+				"operationId": "handleUsingGET",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"additionalProperties": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v3+json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v2+json": {
+								"schema": {
+									"type": "object"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/actuator/health/**": {
+			"get": {
+				"tags": [
+					"operation-handler"
+				],
+				"summary": "handle",
+				"operationId": "handleUsingGET_1",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"additionalProperties": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v3+json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v2+json": {
+								"schema": {
+									"type": "object"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/actuator/info": {
+			"get": {
+				"tags": [
+					"operation-handler"
+				],
+				"summary": "handle",
+				"operationId": "handleUsingGET_2",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"additionalProperties": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v3+json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v2+json": {
+								"schema": {
+									"type": "object"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/actuator": {
+			"get": {
+				"tags": [
+					"web-mvc-links-handler"
+				],
+				"summary": "links",
+				"operationId": "linksUsingGET",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							},
+							"application/vnd.spring-boot.actuator.v3+json": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							},
+							"application/vnd.spring-boot.actuator.v2+json": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"Link": {
+				"title": "Link",
+				"type": "object",
+				"properties": {
+					"href": {
+						"type": "string"
+					},
+					"templated": {
+						"type": "boolean"
+					}
+				}
+			},
+			"ModelAndView": {
+				"title": "ModelAndView",
+				"type": "object",
+				"properties": {
+					"empty": {
+						"type": "boolean"
+					},
+					"model": {
+						"type": "object"
+					},
+					"modelMap": {
+						"type": "object",
+						"additionalProperties": {
+							"type": "object"
+						}
+					},
+					"reference": {
+						"type": "boolean"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ACCEPTED",
+							"ALREADY_REPORTED",
+							"BAD_GATEWAY",
+							"BAD_REQUEST",
+							"BANDWIDTH_LIMIT_EXCEEDED",
+							"CHECKPOINT",
+							"CONFLICT",
+							"CONTINUE",
+							"CREATED",
+							"DESTINATION_LOCKED",
+							"EXPECTATION_FAILED",
+							"FAILED_DEPENDENCY",
+							"FORBIDDEN",
+							"FOUND",
+							"GATEWAY_TIMEOUT",
+							"GONE",
+							"HTTP_VERSION_NOT_SUPPORTED",
+							"IM_USED",
+							"INSUFFICIENT_SPACE_ON_RESOURCE",
+							"INSUFFICIENT_STORAGE",
+							"INTERNAL_SERVER_ERROR",
+							"I_AM_A_TEAPOT",
+							"LENGTH_REQUIRED",
+							"LOCKED",
+							"LOOP_DETECTED",
+							"METHOD_FAILURE",
+							"METHOD_NOT_ALLOWED",
+							"MOVED_PERMANENTLY",
+							"MOVED_TEMPORARILY",
+							"MULTIPLE_CHOICES",
+							"MULTI_STATUS",
+							"NETWORK_AUTHENTICATION_REQUIRED",
+							"NON_AUTHORITATIVE_INFORMATION",
+							"NOT_ACCEPTABLE",
+							"NOT_EXTENDED",
+							"NOT_FOUND",
+							"NOT_IMPLEMENTED",
+							"NOT_MODIFIED",
+							"NO_CONTENT",
+							"OK",
+							"PARTIAL_CONTENT",
+							"PAYLOAD_TOO_LARGE",
+							"PAYMENT_REQUIRED",
+							"PERMANENT_REDIRECT",
+							"PRECONDITION_FAILED",
+							"PRECONDITION_REQUIRED",
+							"PROCESSING",
+							"PROXY_AUTHENTICATION_REQUIRED",
+							"REQUESTED_RANGE_NOT_SATISFIABLE",
+							"REQUEST_ENTITY_TOO_LARGE",
+							"REQUEST_HEADER_FIELDS_TOO_LARGE",
+							"REQUEST_TIMEOUT",
+							"REQUEST_URI_TOO_LONG",
+							"RESET_CONTENT",
+							"SEE_OTHER",
+							"SERVICE_UNAVAILABLE",
+							"SWITCHING_PROTOCOLS",
+							"TEMPORARY_REDIRECT",
+							"TOO_EARLY",
+							"TOO_MANY_REQUESTS",
+							"UNAUTHORIZED",
+							"UNAVAILABLE_FOR_LEGAL_REASONS",
+							"UNPROCESSABLE_ENTITY",
+							"UNSUPPORTED_MEDIA_TYPE",
+							"UPGRADE_REQUIRED",
+							"URI_TOO_LONG",
+							"USE_PROXY",
+							"VARIANT_ALSO_NEGOTIATES"
+						]
+					},
+					"view": {
+						"$ref": "#/components/schemas/View"
+					},
+					"viewName": {
+						"type": "string"
+					}
+				}
+			},
+			"View": {
+				"title": "View",
+				"type": "object",
+				"properties": {
+					"contentType": {
+						"type": "string"
+					}
+				}
+			}
+		}
+	}
+}

--- a/java-apps/bank-gateway/bank-gateway.postman_collection.json
+++ b/java-apps/bank-gateway/bank-gateway.postman_collection.json
@@ -1,0 +1,28 @@
+{
+	"info": {
+		"_postman_id": "f74c7c3f-55a3-4186-bb40-11578255a723",
+		"name": "bank-gateway",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "index",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8110/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8110",
+					"path": [
+						""
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/java-apps/bank-storage/bank-storage.postman_collection.json
+++ b/java-apps/bank-storage/bank-storage.postman_collection.json
@@ -1,0 +1,28 @@
+{
+	"info": {
+		"_postman_id": "f74c7c3f-55a3-4186-bb40-11578255a723",
+		"name": "bank-storage",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "index",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8112/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8112",
+					"path": [
+						""
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/java-apps/bank-storage/pom.xml
+++ b/java-apps/bank-storage/pom.xml
@@ -64,6 +64,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-boot-starter</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.20</version>

--- a/java-apps/bank-storage/swagger-bank-storage.json
+++ b/java-apps/bank-storage/swagger-bank-storage.json
@@ -1,0 +1,1217 @@
+{
+	"openapi": "3.0.3",
+	"info": {
+		"title": "Api Documentation",
+		"description": "Api Documentation",
+		"termsOfService": "urn:tos",
+		"contact": {},
+		"license": {
+			"name": "Apache 2.0",
+			"url": "http://www.apache.org/licenses/LICENSE-2.0"
+		},
+		"version": "1.0"
+	},
+	"servers": [
+		{
+			"url": "http://localhost:8112",
+			"description": "Inferred Url"
+		}
+	],
+	"tags": [
+		{
+			"name": "basic-error-controller",
+			"description": "Basic Error Controller"
+		},
+		{
+			"name": "home-controller",
+			"description": "Home Controller"
+		},
+		{
+			"name": "operation-handler",
+			"description": "Operation Handler"
+		},
+		{
+			"name": "projects-controller",
+			"description": "Projects Controller"
+		},
+		{
+			"name": "web-mvc-links-handler",
+			"description": "Web Mvc Links Handler"
+		}
+	],
+	"paths": {
+		"/error": {
+			"get": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "errorHtml",
+				"operationId": "errorHtmlUsingGET",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"text/html": {
+								"schema": {
+									"$ref": "#/components/schemas/ModelAndView"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"put": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "errorHtml",
+				"operationId": "errorHtmlUsingPUT",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"text/html": {
+								"schema": {
+									"$ref": "#/components/schemas/ModelAndView"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"post": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "errorHtml",
+				"operationId": "errorHtmlUsingPOST",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"text/html": {
+								"schema": {
+									"$ref": "#/components/schemas/ModelAndView"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "errorHtml",
+				"operationId": "errorHtmlUsingDELETE",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"text/html": {
+								"schema": {
+									"$ref": "#/components/schemas/ModelAndView"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"options": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "errorHtml",
+				"operationId": "errorHtmlUsingOPTIONS",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"text/html": {
+								"schema": {
+									"$ref": "#/components/schemas/ModelAndView"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"head": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "errorHtml",
+				"operationId": "errorHtmlUsingHEAD",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"text/html": {
+								"schema": {
+									"$ref": "#/components/schemas/ModelAndView"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"patch": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "errorHtml",
+				"operationId": "errorHtmlUsingPATCH",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"text/html": {
+								"schema": {
+									"$ref": "#/components/schemas/ModelAndView"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"trace": {
+				"tags": [
+					"basic-error-controller"
+				],
+				"summary": "errorHtml",
+				"operationId": "errorHtmlUsingTRACE",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"text/html": {
+								"schema": {
+									"$ref": "#/components/schemas/ModelAndView"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			}
+		},
+		"/": {
+			"get": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingGET",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"put": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingPUT",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"post": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingPOST",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingDELETE",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"options": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingOPTIONS",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"head": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingHEAD",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"patch": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingPATCH",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"trace": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "showWelcomePage",
+				"operationId": "showWelcomePageUsingTRACE",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			}
+		},
+		"/home": {
+			"get": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankStorageIndex",
+				"operationId": "bankStorageIndexUsingGET",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"put": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankStorageIndex",
+				"operationId": "bankStorageIndexUsingPUT",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"post": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankStorageIndex",
+				"operationId": "bankStorageIndexUsingPOST",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"delete": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankStorageIndex",
+				"operationId": "bankStorageIndexUsingDELETE",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"options": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankStorageIndex",
+				"operationId": "bankStorageIndexUsingOPTIONS",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"head": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankStorageIndex",
+				"operationId": "bankStorageIndexUsingHEAD",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"patch": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankStorageIndex",
+				"operationId": "bankStorageIndexUsingPATCH",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			},
+			"trace": {
+				"tags": [
+					"home-controller"
+				],
+				"summary": "bankStorageIndex",
+				"operationId": "bankStorageIndexUsingTRACE",
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"204": {
+						"description": "No Content"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					}
+				}
+			}
+		},
+		"/actuator/health": {
+			"get": {
+				"tags": [
+					"operation-handler"
+				],
+				"summary": "handle",
+				"operationId": "handleUsingGET",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"additionalProperties": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v3+json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v2+json": {
+								"schema": {
+									"type": "object"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/actuator/health/**": {
+			"get": {
+				"tags": [
+					"operation-handler"
+				],
+				"summary": "handle",
+				"operationId": "handleUsingGET_1",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"additionalProperties": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v3+json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v2+json": {
+								"schema": {
+									"type": "object"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/actuator/info": {
+			"get": {
+				"tags": [
+					"operation-handler"
+				],
+				"summary": "handle",
+				"operationId": "handleUsingGET_2",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"additionalProperties": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v3+json": {
+								"schema": {
+									"type": "object"
+								}
+							},
+							"application/vnd.spring-boot.actuator.v2+json": {
+								"schema": {
+									"type": "object"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/projects/check-loan-credibility": {
+			"get": {
+				"tags": [
+					"projects-controller"
+				],
+				"summary": "checkLoanCredibility",
+				"operationId": "checkLoanCredibilityUsingGET",
+				"parameters": [
+					{
+						"name": "clientName",
+						"in": "query",
+						"description": "clientName",
+						"required": true,
+						"style": "form",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Project"
+									}
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/projects/safe": {
+			"get": {
+				"tags": [
+					"projects-controller"
+				],
+				"summary": "findByNameSafe",
+				"operationId": "findByNameSafeUsingGET",
+				"parameters": [
+					{
+						"name": "name",
+						"in": "query",
+						"description": "name",
+						"required": true,
+						"style": "form",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Project"
+									}
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"post": {
+				"tags": [
+					"projects-controller"
+				],
+				"summary": "findByNameSafePost",
+				"operationId": "findByNameSafePostUsingPOST",
+				"parameters": [
+					{
+						"name": "name",
+						"in": "query",
+						"description": "name",
+						"required": true,
+						"style": "form",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "headers",
+						"in": "header",
+						"description": "headers",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Project"
+									}
+								}
+							}
+						}
+					},
+					"201": {
+						"description": "Created"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/projects/unsafe": {
+			"get": {
+				"tags": [
+					"projects-controller"
+				],
+				"summary": "findByNameUnsafe",
+				"operationId": "findByNameUnsafeUsingGET",
+				"parameters": [
+					{
+						"name": "name",
+						"in": "query",
+						"description": "name",
+						"required": true,
+						"style": "form",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/Project"
+									}
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
+		"/actuator": {
+			"get": {
+				"tags": [
+					"web-mvc-links-handler"
+				],
+				"summary": "links",
+				"operationId": "linksUsingGET",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							},
+							"application/vnd.spring-boot.actuator.v3+json": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							},
+							"application/vnd.spring-boot.actuator.v2+json": {
+								"schema": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "object"
+									}
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"Link": {
+				"title": "Link",
+				"type": "object",
+				"properties": {
+					"href": {
+						"type": "string"
+					},
+					"templated": {
+						"type": "boolean"
+					}
+				}
+			},
+			"ModelAndView": {
+				"title": "ModelAndView",
+				"type": "object",
+				"properties": {
+					"empty": {
+						"type": "boolean"
+					},
+					"model": {
+						"type": "object"
+					},
+					"modelMap": {
+						"type": "object",
+						"additionalProperties": {
+							"type": "object"
+						}
+					},
+					"reference": {
+						"type": "boolean"
+					},
+					"status": {
+						"type": "string",
+						"enum": [
+							"ACCEPTED",
+							"ALREADY_REPORTED",
+							"BAD_GATEWAY",
+							"BAD_REQUEST",
+							"BANDWIDTH_LIMIT_EXCEEDED",
+							"CHECKPOINT",
+							"CONFLICT",
+							"CONTINUE",
+							"CREATED",
+							"DESTINATION_LOCKED",
+							"EXPECTATION_FAILED",
+							"FAILED_DEPENDENCY",
+							"FORBIDDEN",
+							"FOUND",
+							"GATEWAY_TIMEOUT",
+							"GONE",
+							"HTTP_VERSION_NOT_SUPPORTED",
+							"IM_USED",
+							"INSUFFICIENT_SPACE_ON_RESOURCE",
+							"INSUFFICIENT_STORAGE",
+							"INTERNAL_SERVER_ERROR",
+							"I_AM_A_TEAPOT",
+							"LENGTH_REQUIRED",
+							"LOCKED",
+							"LOOP_DETECTED",
+							"METHOD_FAILURE",
+							"METHOD_NOT_ALLOWED",
+							"MOVED_PERMANENTLY",
+							"MOVED_TEMPORARILY",
+							"MULTIPLE_CHOICES",
+							"MULTI_STATUS",
+							"NETWORK_AUTHENTICATION_REQUIRED",
+							"NON_AUTHORITATIVE_INFORMATION",
+							"NOT_ACCEPTABLE",
+							"NOT_EXTENDED",
+							"NOT_FOUND",
+							"NOT_IMPLEMENTED",
+							"NOT_MODIFIED",
+							"NO_CONTENT",
+							"OK",
+							"PARTIAL_CONTENT",
+							"PAYLOAD_TOO_LARGE",
+							"PAYMENT_REQUIRED",
+							"PERMANENT_REDIRECT",
+							"PRECONDITION_FAILED",
+							"PRECONDITION_REQUIRED",
+							"PROCESSING",
+							"PROXY_AUTHENTICATION_REQUIRED",
+							"REQUESTED_RANGE_NOT_SATISFIABLE",
+							"REQUEST_ENTITY_TOO_LARGE",
+							"REQUEST_HEADER_FIELDS_TOO_LARGE",
+							"REQUEST_TIMEOUT",
+							"REQUEST_URI_TOO_LONG",
+							"RESET_CONTENT",
+							"SEE_OTHER",
+							"SERVICE_UNAVAILABLE",
+							"SWITCHING_PROTOCOLS",
+							"TEMPORARY_REDIRECT",
+							"TOO_EARLY",
+							"TOO_MANY_REQUESTS",
+							"UNAUTHORIZED",
+							"UNAVAILABLE_FOR_LEGAL_REASONS",
+							"UNPROCESSABLE_ENTITY",
+							"UNSUPPORTED_MEDIA_TYPE",
+							"UPGRADE_REQUIRED",
+							"URI_TOO_LONG",
+							"USE_PROXY",
+							"VARIANT_ALSO_NEGOTIATES"
+						]
+					},
+					"view": {
+						"$ref": "#/components/schemas/View"
+					},
+					"viewName": {
+						"type": "string"
+					}
+				}
+			},
+			"Project": {
+				"title": "Project",
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64"
+					},
+					"name": {
+						"type": "string"
+					}
+				}
+			},
+			"View": {
+				"title": "View",
+				"type": "object",
+				"properties": {
+					"contentType": {
+						"type": "string"
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Problem

For the bank apps to be scannable by the apisec scanner, the Swagger and Postman files should be present in each of them.

### Solution

- generated Swagger files for bank-analysis and bank-storage projects using the Springfox 3.0 dependency (similar to what was already done for the bank-gateway project)
- added simple postman-collection files for each project, with one described API per file (can be enhanced in the future if needed)